### PR TITLE
Remove mode reset on final extraction point

### DIFF
--- a/RepoLastStandMod.cs
+++ b/RepoLastStandMod.cs
@@ -277,12 +277,5 @@ namespace RepoLastStandMod.Patches
         {
             StateManager.Instance.LastStandActive = false;
         }
-
-        [HarmonyPatch("ExtractionCompletedAllRPC")]
-        [HarmonyPrefix]
-        public static void ExtractionCompletedAllRPCPrefix()
-        {
-            StateManager.Instance.LastStandActive = false;
-        }
     }
 }

--- a/RepoLastStandMod.cs
+++ b/RepoLastStandMod.cs
@@ -186,17 +186,17 @@ namespace RepoLastStandMod.Patches
     [HarmonyPatch(typeof(PhysGrabObjectImpactDetector))]
     public static class PhysGrabObjectImpactDetectorPatches
     {
-        [HarmonyPatch("DestroyObjectRPC")]
-        [HarmonyPrefix]
-        public static void DestroyObjectRPCPrefix(bool effects, ValuableObject ___valuableObject)
+        [HarmonyPatch("BreakRPC")]
+        [HarmonyPostfix]
+        public static void BreakRPCPostfix()
         {
-            if (SemiFunc.RunIsLevel() && ___valuableObject is not null)
+            if (SemiFunc.RunIsLevel())
             {
-                OnValuableObjectDestroyed(___valuableObject);
+                AfterValuableObjectBreak();
             }
         }
 
-        private static void OnValuableObjectDestroyed(ValuableObject valuableObject)
+        private static void AfterValuableObjectBreak()
         {
             var roundHaulGoal = RoundDirector.instance.GetInternalHaulGoal();
             // RepoLastStandMod.LoggerInstance.LogInfo($"Round haul goal: {roundHaulGoal}");
@@ -210,14 +210,11 @@ namespace RepoLastStandMod.Patches
             var currentLevelValuablesValue = GetLevelValuablesValue();
             // RepoLastStandMod.LoggerInstance.LogInfo($"Current level valuables value: {currentLevelValuablesValue}");
 
-            var levelValuablesValueAfterValuableDestroyed = currentLevelValuablesValue - valuableObject.dollarValueCurrent;
-            // RepoLastStandMod.LoggerInstance.LogInfo($"Level valuables value after valuable destroyed: {levelValuablesValueAfterValuableDestroyed}");
+            var adjustedLevelValuablesValue = currentLevelValuablesValue + extractedValuablesValue;
+            // RepoLastStandMod.LoggerInstance.LogInfo($"Adjusted level valuables value: {adjustedLevelValuablesValue}");
 
-            var adjustedLevelValuablesValueAfterValuableDestroyed = levelValuablesValueAfterValuableDestroyed + extractedValuablesValue;
-            // RepoLastStandMod.LoggerInstance.LogInfo($"Adjusted level valuables value after valuable destroyed: {adjustedLevelValuablesValueAfterValuableDestroyed}");
-
-            var canStillExtract = adjustedLevelValuablesValueAfterValuableDestroyed >= roundHaulGoal;
-            // RepoLastStandMod.LoggerInstance.LogInfo($"Can still extract: {canStillExtract}");
+            var canStillExtract = adjustedLevelValuablesValue >= roundHaulGoal;
+            RepoLastStandMod.LoggerInstance.LogInfo($"Can still extract: {canStillExtract}");
 
             if (canStillExtract || StateManager.Instance.LastStandActive)
             {


### PR DESCRIPTION
Remove reset logic from ExtractionCompletedAllRPC hook. This was allowing the system to be activated again during final extraction (see #2). Relying on 1 reset during round start should be good enough here.